### PR TITLE
#14282 - Remove disconnection on any error

### DIFF
--- a/src/main/java/io/slingr/endpoints/veritoneuser/VeritoneUserEndpoint.java
+++ b/src/main/java/io/slingr/endpoints/veritoneuser/VeritoneUserEndpoint.java
@@ -67,8 +67,6 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
             apiUri = apiUri + ".uk-1";
         } else if (Objects.equals(region, "uk")) {
             apiUri = apiUri + ".uk";
-        } else if (Objects.equals(region, "no")) {
-            apiUri = apiUri + "";
         } else {
             apiUri = apiUri + region;
         }
@@ -104,12 +102,15 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
 
     @Override
     public void endpointStarted() {
+        logger.info(String.format("Veritone user endpoint started for environment: [%s] and region: [%s]", environment, region));
+        appLogger.info(String.format("Veritone user endpoint started environment: [%s] and region [%s]", environment, region));
         httpService().setAllowExternalUrl(true);
     }
 
     // Authentication process
     @EndpointWebService(path = "authCallback")
     public WebServiceResponse authCallback() {
+        logger.info("Veritone user endpoint callback webservice started from veritone");
         return new WebServiceResponse("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n" +
                 "<html>\n" +
                 "<head>\n" +
@@ -123,6 +124,7 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
     // Connexion process with Veritone from the users Integration
     @EndpointFunction(name = ReservedName.CONNECT_USER)
     public Json connectUser(FunctionRequest request) {
+        logger.info(String.format("Event connect user received from request [%s] for user [%s]", request, request.getUserId()));
         final String userId = request.getUserId();
         if (StringUtils.isNotBlank(userId)) {
             String accessToken = request.getJsonParams().string("accessToken");
@@ -136,13 +138,13 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
                 return accessTokenRequest(request, userId);
             }
         }
-        defaultMethodDisconnectUsers(request);
         return Json.map();
     }
 
     // First try to get the access token from the user configuration with the code
     private Json accessTokenRequest(FunctionRequest request, String userId) {
         // checks if the user includes a non-empty 'code' on the request
+        logger.info("Get access token from request");
         final Json jsonBody = request.getJsonParams();
         if (jsonBody != null && StringUtils.isNotBlank(jsonBody.string("code"))) {
             String code = jsonBody.string("code");
@@ -155,17 +157,21 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
                             .set("redirect_uri", jsonBody.string("redirectUri"))
                             .set("grant_type", "authorization_code")
                     );
+            logger.info(String.format("Executing post to get access token [%s]", accessTokenRequest. toPrettyString()));
             Json res = RestClient.builder(getAIDataApiUri().concat("/v1/admin/oauth/token")).httpPost(accessTokenRequest);
             if (res.contains("access_token")) {
+                logger.info(String.format("Access token received [%s], saving it to user [%s]", res, userId));
                 return setUserConnected(request, userId, res);
             } else {
-                logger.warn(String.format("Problems trying to connect user [%s] to Veritone: %s", userId, res));
-                appLogger.warn(String.format("Problems trying to connect user [%s] to Veritone %s", userId, res.string("error")));
+                logger.warn(String.format("Problems trying to connect user [%s] to veritone: %s", userId, res));
+                appLogger.warn(String.format("Problems trying to connect user [%s] to veritone %s", userId, res.string("error")));
+                return Json.map();
             }
         } else {
-            logger.info(String.format("Empty 'code' when try to connect user [%s] [%s]", userId, request));
+            logger.warn(String.format("Empty 'code' when try to connect user [%s] [%s]", userId, request));
+            appLogger.warn("Problems trying to connect user empty 'code'");
+            return Json.map();
         }
-        return Json.map();
     }
 
     // Save the user configuration
@@ -178,6 +184,7 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
 
     // If the access token is expired, try to get a new one and save it
     private void generateNewAccessToken(FunctionRequest request) {
+        logger.info("Get access token with refresh token");
         final String userId = request.getUserId();
         Json userConfig = users().findById(userId);
         if (userConfig == null || userConfig.isEmpty("refresh_token")) {
@@ -193,12 +200,13 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
                         .set("refresh_token", refreshToken)
                 );
         try {
+            logger.info(String.format("Executing post to get a new access token [%s]", accessTokenRequest.toPrettyString()));
             Json res = RestClient.builder(getAIDataApiUri().concat("/v1/admin/oauth/token")).httpPost(accessTokenRequest);
             if (res.contains("access_token")) {
                 setUserConnected(request, userId, res);
             } else {
-                logger.warn(String.format("Problems trying to connect user [%s] to Veritone: %s", userId, res));
-                appLogger.warn(String.format("Problems trying to connect user [%s] to Veritone %s", userId, res.string("error")));
+                logger.warn(String.format("Problems trying to re-connect user [%s] to veritone: %s", userId, res));
+                appLogger.warn(String.format("Problems trying to re-connect user [%s] to veritone %s", userId, res.string("error")));
             }
         } catch (Exception e) {
             appLogger.error(String.format("Error refreshing token for client ID [%s]. You might need to get a new refresh token.", clientId));
@@ -219,7 +227,12 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
                 setUserRequestHeaders(request);
                 return defaultGetRequest(request);
             } else if (restException.getCode() == ErrorCode.CLIENT) {
-                users().sendUserDisconnectedEvent(request.getUserId());
+                logger.error(String.format("Problems trying to execute request [%s] exception: [%s]", request, restException));
+                appLogger.error("Endpoint client error trying to execute request, verify your metadata.");
+                appLogger.info("Retrying request.");
+                generateNewAccessToken(request);
+                setUserRequestHeaders(request);
+                return defaultGetRequest(request);
             }
             throw restException;
         }
@@ -238,7 +251,12 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
                 setUserRequestHeaders(request);
                 return defaultPostRequest(request);
             } else if (restException.getCode() == ErrorCode.CLIENT) {
-                users().sendUserDisconnectedEvent(request.getUserId());
+                logger.error(String.format("Problems trying to execute request [%s] exception: [%s]", request, restException));
+                appLogger.error("Endpoint client error trying to execute request, verify your metadata.");
+                appLogger.info("Retrying request.");
+                generateNewAccessToken(request);
+                setUserRequestHeaders(request);
+                return defaultPostRequest(request);
             }
             throw restException;
         }
@@ -257,7 +275,12 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
                 setUserRequestHeaders(request);
                 return defaultPutRequest(request);
             } else if (restException.getCode() == ErrorCode.CLIENT) {
-                users().sendUserDisconnectedEvent(request.getUserId());
+                logger.error(String.format("Problems trying to execute request [%s] exception: [%s]", request, restException));
+                appLogger.error("Endpoint client error trying to execute request, verify your metadata.");
+                appLogger.info("Retrying request.");
+                generateNewAccessToken(request);
+                setUserRequestHeaders(request);
+                return defaultPutRequest(request);
             }
             throw restException;
         }
@@ -276,7 +299,12 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
                 setUserRequestHeaders(request);
                 return defaultPatchRequest(request);
             } else if (restException.getCode() == ErrorCode.CLIENT) {
-                users().sendUserDisconnectedEvent(request.getUserId());
+                logger.error(String.format("Problems trying to execute request [%s] exception: [%s]", request, restException));
+                appLogger.error("Endpoint client error trying to execute request, verify your metadata.");
+                appLogger.info("Retrying request.");
+                generateNewAccessToken(request);
+                setUserRequestHeaders(request);
+                return defaultPatchRequest(request);
             }
             throw restException;
         }
@@ -295,7 +323,12 @@ public class VeritoneUserEndpoint extends HttpPerUserEndpoint {
                 setUserRequestHeaders(request);
                 return defaultDeleteRequest(request);
             } else if (restException.getCode() == ErrorCode.CLIENT) {
-                users().sendUserDisconnectedEvent(request.getUserId());
+                logger.error(String.format("Problems trying to execute request [%s] exception: [%s]", request, restException));
+                appLogger.error("Endpoint client error trying to execute request, verify your metadata.");
+                appLogger.info("Retrying request.");
+                generateNewAccessToken(request);
+                setUserRequestHeaders(request);
+                return defaultDeleteRequest(request);
             }
             throw restException;
         }


### PR DESCRIPTION
Pull-request for issue #14282 created by @pasaperez-slingr

## What it does?

Fixes the error that if there is any error or Exception triggered by the endpoint (inside the SDK) it triggers the `clientException` exception and disconnects the user, now it no longer throws a disconnection to the user who made the request. Also adds a retry to these error cases. 

## How to test it?

Make calls from the platform for example using the console using the information provided in the documentation.

## Implementation notes

Create a new tag of the endpoint.

## Deployment notes

There are no deployment notes